### PR TITLE
Android background location access permission added for android Q.

### DIFF
--- a/Android/app/build.gradle
+++ b/Android/app/build.gradle
@@ -6,11 +6,11 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
     defaultConfig {
         applicationId "bd.coronatracker.com.coronatracker"
         minSdkVersion 23
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/Android/app/src/main/java/bd/ctracker/com/ctracker/activity/TrackingActivity.kt
+++ b/Android/app/src/main/java/bd/ctracker/com/ctracker/activity/TrackingActivity.kt
@@ -37,6 +37,15 @@ class TrackingActivity : AppCompatActivity() {
         title = "Tracking"
         setContentView(R.layout.activity_tracker)
 
+        if(android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.Q){
+            requestAccessFineLocation()
+        } else{
+            requestAccessBackgroundLocation()
+        }
+    }
+
+    private fun requestAccessFineLocation() {
+
         if (ActivityCompat.checkSelfPermission(
                 this,
                 Manifest.permission.ACCESS_FINE_LOCATION
@@ -59,6 +68,33 @@ class TrackingActivity : AppCompatActivity() {
         }
     }
 
+    private fun requestAccessBackgroundLocation(){
+        if (ActivityCompat.checkSelfPermission(
+                this,
+                Manifest.permission.ACCESS_FINE_LOCATION
+            ) != PackageManager.PERMISSION_GRANTED
+            && ActivityCompat.checkSelfPermission(
+                this,
+                Manifest.permission.ACCESS_COARSE_LOCATION
+            ) != PackageManager.PERMISSION_GRANTED
+            && ActivityCompat.checkSelfPermission(
+                this,
+                Manifest.permission.ACCESS_BACKGROUND_LOCATION
+            ) != PackageManager.PERMISSION_GRANTED
+        ) {
+            ActivityCompat.requestPermissions(
+                this,
+                arrayOf(
+                    Manifest.permission.ACCESS_FINE_LOCATION,
+                    Manifest.permission.ACCESS_COARSE_LOCATION,
+                    Manifest.permission.ACCESS_BACKGROUND_LOCATION
+                ),
+                MY_PERMISSIONS_REQUEST_LOCATION
+            )
+        } else {
+            startService(serviceIntent)
+        }
+    }
 
     override fun onRequestPermissionsResult(
         requestCode: Int,
@@ -89,14 +125,26 @@ class TrackingActivity : AppCompatActivity() {
                         )
 
                 } else {
-                    ActivityCompat.requestPermissions(
-                        this,
-                        arrayOf(
-                            Manifest.permission.ACCESS_FINE_LOCATION,
-                            Manifest.permission.ACCESS_COARSE_LOCATION
-                        ),
-                        MY_PERMISSIONS_REQUEST_LOCATION
-                    )
+                    if(android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.Q){
+                        ActivityCompat.requestPermissions(
+                            this,
+                            arrayOf(
+                                Manifest.permission.ACCESS_FINE_LOCATION,
+                                Manifest.permission.ACCESS_COARSE_LOCATION
+                            ),
+                            MY_PERMISSIONS_REQUEST_LOCATION
+                        )
+                    } else {
+                        ActivityCompat.requestPermissions(
+                            this,
+                            arrayOf(
+                                Manifest.permission.ACCESS_FINE_LOCATION,
+                                Manifest.permission.ACCESS_COARSE_LOCATION,
+                                Manifest.permission.ACCESS_BACKGROUND_LOCATION
+                            ),
+                            MY_PERMISSIONS_REQUEST_LOCATION
+                        )
+                    }
                 }
             }
         }


### PR DESCRIPTION
* Changed compiled SDK version and targetSDK version to latest.
* Have put access background location permission as android 10 requires this permission for getting the device location when the app is in background mode.
 
Signed-off-by: Mohtasim Bellah <mohtasim22@gmail.com>